### PR TITLE
ENV["USE_INTEL_MKL"] switch to allow reverting back to OpenBLAS

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,9 +1,21 @@
 using PackageCompiler
 using MKL_jll
 
-# if no environment variable ENV["USE_BLAS64"] is set install.jl
-# tries to change USE_BLAS64 = false
-const USEBLAS64 = parse(Bool,get(ENV, "USE_BLAS64","false"))
+# ENV["USE_INTEL_MKL"] decides whether we are
+# enabling MKL (true, default) or OpenBLAS (false).
+const USEINTELMKL = parse(Bool,get(ENV, "USE_INTEL_MKL","true"))
+
+# ENV["USE_BLAS64"] decides wheter we use 64 bit (true) or 32 bit (false, default) BLAS.
+# If USEINTELMKL == false, i.e. we are enabling OpenBLAS, the user setting
+# is overwritten and we always USEBLAS64 = true.
+const USEBLAS64 = USEINTELMKL ? parse(Bool,get(ENV, "USE_BLAS64","false")) : true
 
 include("../src/install.jl")
-enable_mkl_startup()
+
+if USEINTELMKL
+	@info "Enabling Intel MKL...."
+	enable_mkl_startup()
+else
+	@info "Enabling OpenBLAS...."
+	enable_openblas_startup()
+end


### PR DESCRIPTION
See https://github.com/JuliaComputing/MKL.jl/issues/58.

In this PR I introduce the option to switch back to using OpenBLAS for linear algebra operations. Specifically, if one sets `ENV["USE_INTEL_MKL"] = false` and then `] build MKL` one gets back

```Julia
julia> BLAS.vendor()
:openblas64
```

Since `ENV["USE_BLAS64"] = false` leads to an error when enabling OpenBLAS I ignore the user set value in this case (and always consider the 64 bit option).