### PR TITLE
Run on Julia 1.5 (by building sysimg) and 1.7 (with LBT) in the same codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - "1"
+          - "1.5"
           - "nightly"
         os:
           - ubuntu-latest
@@ -45,6 +45,6 @@ jobs:
         shell: julia --color=yes --project="" {0}
         run: |
           using Pkg
-          Pkg.develop(PackageSpec(path="."))
+          Pkg.develop(PackageSpec(path=pwd()))
           Pkg.build("MKL"; verbose=true)
       - uses: julia-actions/julia-runtest@latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,19 +1,20 @@
 name = "MKL"
 uuid = "33e6dc65-8f57-5167-99aa-e5a354878fb2"
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 
 [compat]
 PackageCompiler = "1"
 julia = "1.3"
+MKL_jll = "2021"
 
 [extras]
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "LinearAlgebra"]
+test = ["Test"]

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,7 @@
+if VERSION > v"1.6"
+    exit() # Don't want to build the system image, since we will use LBT
+end
+
 using PackageCompiler
 using MKL_jll
 

--- a/src/MKL.jl
+++ b/src/MKL.jl
@@ -1,12 +1,12 @@
 module MKL
 
 using MKL_jll
+VERSION > v"1.7.0-DEV.623" && using LinearAlgebra
 
-# We cannot depend on LinearAlgebra since we need to be loaded before it
 if Base.USE_BLAS64
-    const BlasInt = Int64
+    const MKLBlasInt = Int64
 else
-    const BlasInt = Int32
+    const MKLBlasInt = Int32
 end
 
 @enum Threading begin
@@ -16,6 +16,7 @@ end
     THREADING_GNU
     THREADING_TBB
 end
+
 @enum Interface begin
     INTERFACE_LP64
     INTERFACE_ILP64
@@ -23,34 +24,31 @@ end
 end
 
 function set_threading_layer(layer::Threading = THREADING_INTEL)
-    err = ccall((:MKL_Set_Threading_Layer, libmkl_rt), Cint,
-        (Cint,), layer)
-    if err == -1
-        throw(ErrorException("return value was -1"))
-    end
+    err = ccall((:MKL_Set_Threading_Layer, libmkl_rt), Cint, (Cint,), layer)
+    err == -1 && throw(ErrorException("return value was -1"))
     return nothing
 end
 
-function set_interface_layer(interface = BlasInt == Int64 ? INTERFACE_ILP64 : INTERFACE_LP64)
-    err = ccall((:MKL_Set_Interface_Layer, libmkl_rt), Cint,
-        (Cint,), interface)
-    if err == -1
-        throw(ErrorException("return value was -1"))
-    end
+function set_interface_layer(interface = Base.USE_BLAS64 ? INTERFACE_ILP64 : INTERFACE_LP64)
+    err = ccall((:MKL_Set_Interface_Layer, libmkl_rt), Cint, (Cint,), interface)
+    err == -1 && throw(ErrorException("return value was -1"))
     return nothing
 end
 
 function __init__()
-    set_threading_layer()
-    set_interface_layer()
+    if MKL_jll.is_available()
+        set_threading_layer()
+        set_interface_layer()
+        VERSION > v"1.7.0-DEV.623" && BLAS.lbt_forward(libmkl_rt, clear=true)
+    end
 end
 
-mklnorm(x::Vector{Float64}) = ccall((:dnrm2_, libmkl_rt), Float64,
-    (Ref{BlasInt}, Ptr{Float64}, Ref{BlasInt}),
-    length(x), x, 1)
-
-
-# Include installation routines as well
-include("install.jl")
-
+function mklnorm(x::Vector{Float64})
+    ccall((:dnrm2_, libmkl_rt), Float64,
+          (Ref{MKLBlasInt}, Ptr{Float64}, Ref{MKLBlasInt}),
+          length(x), x, 1)
 end
+
+VERSION > v"1.7.0-DEV.623" && include("install.jl")
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,12 @@
-using Test
 using LinearAlgebra
+using MKL
+using MKL_jll
+using Test
 
-@test BLAS.vendor() == :mkl
+if VERSION > v"1.7.0-DEV.623"
+    @test BLAS.get_config().loaded_libs[1].libname == libmkl_rt
+else
+    @test BLAS.vendor() == :mkl
+end
+
+@test LinearAlgebra.peakflops() > 0


### PR DESCRIPTION
Improved version of #62 

Use LBT for Julia releases that have it, and the sysimg method otherwise. Julia 1.6 is not yet compatible with with the MKL sysimage building.