### PR TITLE
Fix package building step in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,6 @@ jobs:
         shell: julia --color=yes --project="" {0}
         run: |
           using Pkg
-          Pkg.develop(PackageSpec(path="."))
+          Pkg.develop(PackageSpec(path=pwd()))
           Pkg.build("MKL"; verbose=true)
       - uses: julia-actions/julia-runtest@latest


### PR DESCRIPTION
I don't know if it's a Pkg issue or an internal Julia one, but when the current directory is `D:\a\MKL.jl\MKL.jl`, `PackageSpec(path=pwd()` is expanded to `C:\D:\a\MKL.jl\MKL.jl`, causing the error we're seeing in #63.  Passing the explicit `pwd()` seems to work around the issue.

CC: @ViralBShah 