### PR TITLE
Add Artifacts as dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,15 +3,16 @@ uuid = "33e6dc65-8f57-5167-99aa-e5a354878fb2"
 version = "0.4.0"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 
 [compat]
+MKL_jll = "2021"
 PackageCompiler = "1"
 julia = "1.3"
-MKL_jll = "2021"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/install.jl
+++ b/src/install.jl
@@ -63,7 +63,11 @@ function insert_MKL_load(base_dir)
     end
 
     # After this the stdlibs get included, so insert MKL to be loaded here
-    start_idx = findfirst(match.(r"Base._track_dependencies\[\] = true", lines) .!= nothing)
+    if VERSION >= v"1.6.0"
+        start_idx = findfirst(match.(r"# Stdlibs sorted in dependency, then alphabetical, order by contrib/print_sorted_stdlibs.jl", lines) .!= nothing)
+    else
+        start_idx = findfirst(match.(r"Base._track_dependencies\[\] = true", lines) .!= nothing)
+    end
 
     splice!(lines, (start_idx + 1):start_idx, MKL_PAYLOAD_LINES)
     write(file, string(join(lines, '\n'), '\n'))


### PR DESCRIPTION
Fixes #60.

From reading the discussion in #60 and trying a number of approaches, this seems like the preferred fix to make MKL.jl build under Julia 1.6. Contrary to some people's worries, this does not break anything for versions < 1.6: I've tested on 1.3.1, 1.4.2, 1.5.4, 1.6.0, and 1.6.1, and MKL.jl with this patch builds successfully on all of them (1.6.1 requires an additional, unrelated fix, see #79).

I considered the possibility that the problem is really in PackageCompiler.jl, but adding Artifacts as a dependency there instead of in MKL.jl did not fix the problem.