### PR TITLE
Fix version criterion for build vs. LBT

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,6 @@
-if VERSION > v"1.6"
+using MKL
+
+if VERSION > MKL.JULIA_VER_NEEDED
     exit() # Don't want to build the system image, since we will use LBT
 end
 


### PR DESCRIPTION
The previous criterion would erroneously abort the build process for julia 1.6.1. This fix makes the version criteria consistent between package loading and package building.