### PR TITLE
[WIP] Option to use system MKL instead of MKL_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,8 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
 MKL_jll = "2021"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,15 +1,63 @@
-using MKL
+# using MKL
+using Preferences
+using Pkg
+using Libdl
 
-if VERSION > MKL.JULIA_VER_NEEDED
-    exit() # Don't want to build the system image, since we will use LBT
+const JULIA_VER_NEEDED = v"1.7.0-DEV.641"
+is_lbt_available() = VERSION > JULIA_VER_NEEDED
+
+function find_uuid_in_project(name)
+    get(Pkg.Types.EnvCache().project.deps, name, nothing)
 end
 
-using PackageCompiler
-using MKL_jll
+if is_lbt_available()
+    # Julia version >= 1.7: Use LBT
+    const MKL_uuid = find_uuid_in_project("MKL")
 
-# if no environment variable ENV["USE_BLAS64"] is set install.jl
-# tries to change USE_BLAS64 = false
-const USEBLAS64 = parse(Bool,get(ENV, "USE_BLAS64","false"))
+    # 1. update preferences based on env variables if necessary
+    if haskey(ENV, "JULIA_MKL_USE_JLL")
+        use_jll = lowercase(get(ENV, "JULIA_MKL_USE_JLL", "true"))
+        set_preferences!(MKL_uuid, "use_jll" => use_jll)
+    end
 
-include("../src/install.jl")
-enable_mkl_startup()
+    if haskey(ENV, "JULIA_MKL_PATH")
+        mkl_path = lowercase(get(ENV, "JULIA_MKL_PATH", "true"))
+        set_preferences!(MKL_uuid, "mkl_path" => mkl_path)
+    end
+
+    @show has_preference(MKL_uuid, "use_jll")
+
+    # 2. set up libraries
+    use_jll = load_preference(MKL_uuid, "use_jll", "true")
+    mkl_path = load_preference(MKL_uuid, "mkl_path", "")
+
+    if parse(Bool, use_jll)
+        @info "MKL provider: MKL_jll (default)."
+        using MKL_jll # force download of artifacts
+    else
+        @info "MKL provider: System"
+        mkl_path != "" && (@info "Explicit MKL path set: ")
+
+        @info "Checking availability of libmkl_core and libmkl_rt"
+        if find_library(["libmkl_core"], mkl_path) == ""
+            error("libmkl_core could not be found")
+        end
+        if find_library(["libmkl_rt"], mkl_path) == ""
+            error("libmkl_rt could not be found")
+        end
+    end
+else
+    # Julia versions < 1.7: Build a custom system image
+    using PackageCompiler
+    using MKL_jll
+
+    # if no environment variable ENV["USE_BLAS64"] is set install.jl
+    # tries to change USE_BLAS64 = false
+    const USEBLAS64 = parse(Bool,get(ENV, "USE_BLAS64","false"))
+
+    include("../src/install.jl")
+    enable_mkl_startup()
+end
+
+# Why?
+using MKL


### PR DESCRIPTION
This is a quick first attempt to solve https://github.com/JuliaLinearAlgebra/MKL.jl/issues/82 based on the ideas discussed in the context of MPI.jl here: https://github.com/JuliaParallel/MPI.jl/issues/483.

Essentially, I'm trying to add a package preference `use_jll` to MKL.jl (using [Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl)) based on which the package desides to `using MKL_jll` or setting `const libmkl_core` and `const libmkl_rt` explicitly (pointing to a system MKL). The desired workflow is: (1) set `JULIA_MKL_USE_JLL=false` (2) `build MKL` -> MKL_jll artifact is never downloaded (it is [lazy](https://github.com/JuliaBinaryWrappers/MKL_jll.jl/blob/main/Artifacts.toml#L4)) and system MKL is used.

Sharing this early attempt (which might turn out as rubbish) to facilitate a discussion with @staticfloat started on Slack.