### PR TITLE
Add mkl_provider option to support using "system" MKL

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
 MKL_jll = "2021"

--- a/src/MKL.jl
+++ b/src/MKL.jl
@@ -1,6 +1,48 @@
 module MKL
 
-using MKL_jll
+using Preferences
+using Libdl
+
+# Choose an MKL provider; taking an explicit preference as the first choice,
+# but if nothing is set as a preference, fall back to an environment variable,
+# and if that is not given, fall back to the default choice of `MKL_jll`.
+const mkl_provider = lowercase(something(
+    @load_preference("mkl_provider", nothing),
+    get(ENV, "JULIA_MKL_PROVIDER", nothing),
+    "mkl_jll",
+)::String)
+
+if mkl_provider == "mkl_jll"
+    # Only load MKL_jll if we are suppoed to use it as the MKL source
+    # to avoid an unnecessary download of the (lazy) artifact.
+    import MKL_jll
+    const libmkl_rt = MKL_jll.libmkl_rt
+    const mkl_path = dirname(libmkl_rt)
+elseif mkl_provider == "system"
+    # We want to use a "system" MKL, so let's try to find it.
+    # The user may provide the path to libmkl_rt via a preference
+    # or an environment variable. Otherwise, we expect it to
+    # already be loaded, or be on our linker search path.
+    const mkl_path = lowercase(something(
+        @load_preference("mkl_path", nothing),
+        get(ENV, "JULIA_MKL_PATH", nothing),
+        "",
+    )::String)
+    const libmkl_rt = find_library(["libmkl_rt"], [mkl_path])
+    libmkl_rt == "" && error("Couldn't find libmkl_rt. Maybe set JULIA_MKL_PATH?")
+else
+    error("Invalid mkl_provider choice $(mkl_provider).")
+end
+
+# Changing the MKL provider preference
+function set_mkl_provider(provider)
+    if lowercase(provider) ∉ ("mkl_jll", "system")
+        error("Invalid mkl_provider choice $(provider)")
+    end
+    @set_preferences!("mkl_provider" => lowercase(provider))
+
+    @info("New MKL provider set; please restart Julia to see this take effect", provider)
+end
 
 JULIA_VER_NEEDED = v"1.7.0-DEV.641"
 VERSION > JULIA_VER_NEEDED && using LinearAlgebra
@@ -38,11 +80,11 @@ function set_interface_layer(interface = Base.USE_BLAS64 ? INTERFACE_ILP64 : INT
 end
 
 function __init__()
-    if MKL_jll.is_available()
-        set_threading_layer()
-        set_interface_layer()
-        VERSION > JULIA_VER_NEEDED && BLAS.lbt_forward(libmkl_rt, clear=true)
-    end
+    # if MKL_jll.is_available()
+    set_threading_layer()
+    set_interface_layer()
+    VERSION > JULIA_VER_NEEDED && BLAS.lbt_forward(libmkl_rt, clear=true)
+    # end
 end
 
 function mklnorm(x::Vector{Float64})
@@ -50,7 +92,5 @@ function mklnorm(x::Vector{Float64})
           (Ref{MKLBlasInt}, Ptr{Float64}, Ref{MKLBlasInt}),
           length(x), x, 1)
 end
-
-VERSION > JULIA_VER_NEEDED && include("install.jl")
 
 end # module

--- a/src/MKL.jl
+++ b/src/MKL.jl
@@ -28,8 +28,9 @@ elseif mkl_provider == "system"
         get(ENV, "JULIA_MKL_PATH", nothing),
         "",
     )::String)
-    const libmkl_rt = find_library(["libmkl_rt"], [mkl_path])
-    libmkl_rt == "" && error("Couldn't find libmkl_rt. Maybe set JULIA_MKL_PATH?")
+    libname = string("libmkl_rt", ".", Libdl.dlext)
+    const libmkl_rt = find_library(libname, [mkl_path])
+    libmkl_rt == "" && error("Couldn't find $libname. Maybe try setting JULIA_MKL_PATH?")
 else
     error("Invalid mkl_provider choice $(mkl_provider).")
 end
@@ -44,8 +45,9 @@ function set_mkl_provider(provider)
     @info("New MKL provider set; please restart Julia to see this take effect", provider)
 end
 
-JULIA_VER_NEEDED = v"1.7.0-DEV.641"
-VERSION > JULIA_VER_NEEDED && using LinearAlgebra
+is_lbt_available() = VERSION > v"1.7.0-DEV.641"
+
+is_lbt_available() && using LinearAlgebra
 
 if Base.USE_BLAS64
     const MKLBlasInt = Int64
@@ -83,7 +85,7 @@ function __init__()
     # if MKL_jll.is_available()
     set_threading_layer()
     set_interface_layer()
-    VERSION > JULIA_VER_NEEDED && BLAS.lbt_forward(libmkl_rt, clear=true)
+    is_lbt_available() && BLAS.lbt_forward(libmkl_rt, clear=true)
     # end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using LinearAlgebra
 using MKL
-using MKL_jll
 using Test
 
 if VERSION > MKL.JULIA_VER_NEEDED


### PR DESCRIPTION
Addressing #82, this PR adds the option to use a "system" MKL, i.e. an external `libmkl_rt`, instead of the one provided by MKL_jll.jl.

Specifically, a user may specify a `mkl_provider` via a [preference](https://github.com/JuliaPackaging/Preferences.jl), or the environment variable `JULIA_MKL_PROVIDER`. Supported are the values `mkl_jll` (default) and `system`. If `system` is chosen, we check that `libmkl_rt` is available on the linker search path, i.e. `Libdl.find_library` is able to find it, or otherwise throw an error. The user may also specify the path to `libmkl_rt` explicitly, either via the environment variable `JULIA_MKL_PATH` or the preference `mkl_path`. The function `set_mkl_provider` can be used to change the MKL provider preference (it retriggers compilation in contrast to changing the environment variable, which won't have any effect).

Note that with this PR we only call `using MKL_jll` if it is really needed. Combined with the [laziness](https://github.com/JuliaBinaryWrappers/MKL_jll.jl/blob/main/Artifacts.toml#L4) of the MKL_jll artifact this ensures that the ~1.5 GB (on linux) MKL dependency is only downloaded if `mkl_provider = "mkl_jll"` (default) but not when `mkl_provider = "system"`.

Credit: This PR is largely inspired by a draft implementation by @staticfloat which originated out of a Slack discussion.

**Demo of `JULIA_MKL_PROVIDER=system`:**
<img width="1904" alt="Screenshot 2021-07-14 at 23 08 41" src="https://user-images.githubusercontent.com/187980/125693227-ada44ccc-e07a-472e-82ff-cd8781056f97.png">

**The artifact is only downloaded when needed:**
<img width="1236" alt="Screenshot 2021-07-14 at 23 14 12" src="https://user-images.githubusercontent.com/187980/125693909-3de5d549-24b7-438d-a570-52f177de1a21.png">

TODOs:
[ ] Update README.md
[ ] I commented out https://github.com/crstnbr/MKL.jl/blob/systemmkl2/src/MKL.jl#L85 in this PR. I think this can be dropped?
[ ] Check that Julia 1.6 (no LBT) still works correctly

Closes #82