### PR TITLE
Run all the LinearAlgebra tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Pkg"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,5 @@
-using LinearAlgebra
-using MKL
-using MKL_jll
-using Test
+using MKL, MKL_jll, LinearAlgebra
+using Pkg, Test
 
 if VERSION > MKL.JULIA_VER_NEEDED
     @test BLAS.get_config().loaded_libs[1].libname == libmkl_rt
@@ -10,3 +8,5 @@ else
 end
 
 @test LinearAlgebra.peakflops() > 0
+
+Pkg.test("LinearAlgebra")


### PR DESCRIPTION
Fix for #70 

Note that for Julia versions older than 1.7, the system image (with MKL) building fails because the process of overwriting it is unreliable in CI (e.g. on macOS we can't overwrite at all, and linux and windows have other issues). This will not really be a problem since 1.7 will be out soon and so the stable as well as the nightly tests will pass.

We don't expect this package to change a whole lot. The main purpose of these tests is actually for `PkgEval`.