### PR TITLE
Update README.md to trigger CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Libraries:
 └ [ILP64] libmkl_rt.1.dylib
 ```
 
-
 ## Using the 64-bit vs 32-bit version of MKL
 
 We use ILP64 by default on 64-bit systems, and LP64 on 32-bit systems.


### PR DESCRIPTION
@amontoison - Running CI here to see if we can tag MKL 0.6. We can tag MKL 0.6 if this basically works on all the platforms. There are some tests failing because of numerical precision mismatch in MKL 2021/2022, e.g. `gsvd` - but that shouldn't hold up the version bump.

This should help https://github.com/jump-dev/Ipopt.jl/pull/327