### PR TITLE
Ignore environment changes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,6 @@ jobs:
           Pkg.develop(PackageSpec(path=pwd()))
           Pkg.build("MKL"; verbose=true)
       - uses: julia-actions/julia-runtest@latest
+        env:
+          # Loading MKL during the tests can create an environment variable for OpenMP that is visible after the tests (#130)
+          JULIA_TEST_CHECK_MUTATED_ENV: "false"


### PR DESCRIPTION
The test suite needs to ignore any changes to the environment because loading MKL's shared library on some platforms (such as Windows) can create environment variables for OpenMP (e.g. __KMP_REGISTERED_LIB_<PID>) that live the entire Julia session and make the environment appear modified. 

This should fix the Windows CI, but the other ones will still probably fail.

Fixes #130