### PR TITLE
Introduce manual mapping of some ILP64 routines

### DIFF
--- a/src/MKL.jl
+++ b/src/MKL.jl
@@ -50,6 +50,35 @@ function __init__()
             BLAS.lbt_forward(libmkl_rt; clear=true, suffix_hint="64")
             # Load LP64 forward
             BLAS.lbt_forward(libmkl_rt; suffix_hint="")
+
+            # Some BLAS/LAPACK functions that don't have integers in their API aren't exported
+            # from libmkl_rt with the 64 suffix, and instead we must map the ILP64 to the
+            # non-suffixed variants
+            for f in (:dlartgp_,  :slartgp_,
+                      :dlartgs_,  :slartgs_,
+                      :disnan_,   :sisnan_,
+                      :dlabad_,   :slabad_,
+                      :dladiv_,   :sladiv_,
+                      :dlae2_,    :slae2_,
+                      :dlaev2_,   :slaev2_,
+                      :dlaisnan_, :slaisnan_,
+                      :dlamch_,   :slamch_,
+                      :dlamc3_,   :slamc3_,
+                      :dlanv2_,   :slanv2_,
+                      :dlapy2_,   :slapy2_,
+                      :dlapy3_,   :slapy3_,
+                      :dlartg_,   :slartg_,
+                      :dlas2_,    :slas2_,
+                      :dsecnd_,   :second_,
+                      :dlasv2_,   :slasv2_,
+                      :iladiag_,
+                      :ilaprec_,
+                      :ilatrans_,
+                      :ilauplo_,
+                      )
+                fptr = BLAS.lbt_get_forward(f, BLAS.LBT_INTERFACE_LP64)
+                BLAS.lbt_set_forward(f, fptr, BLAS.LBT_INTERFACE_ILP64)
+            end
         else
             BLAS.lbt_forward(libmkl_rt; clear=true, suffix_hint="")
         end


### PR DESCRIPTION
MKL doesn't export all routines over the ILP64 interface in libmkl_rt, specifically it doesn't export functions that might not be affected by the differing integer sizes (e.g. no integers used in the API).

In these cases, we can redirect the ILP64 version to the LP64 version to maintain compatibility.

This list is not complete, but is basically what I found scrolling through the lapack header provided with MKL. We should ideally find a way to automate finding these functions and script it.

First noticed in #138.