### PR TITLE
CI: don't run CompatHelper on every push to master

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -2,9 +2,7 @@ name: CompatHelper
 on:
   schedule:
     - cron: '0 0 * * *'
-  push:
-      branches:
-        - 'main'
+  workflow_dispatch:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It's not necessary to run CompatHelper on every push to master.

Instead, it's sufficient to run CompatHelper as a once-daily cron job.

Also, we add a `workflow_dispatch` trigger, so that we can manually trigger a CompatHelper run if we want.