### PR TITLE
Update README.md, add hint how to fix Windows installation issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Adding the package will replace the system BLAS and LAPACK with MKL provided one
 ```julia
 julia> using Pkg; Pkg.add("MKL")
 ```
+***Hint:*** On Windows the installation might fail due to a missing library with the name `VCRUNTIME140.dll`. To install it, download and execute https://aka.ms/vs/17/release/vc_redist.x64.exe .
 
 ## To Check Installation:
 


### PR DESCRIPTION
Add hint how to fix the problem with the missing `VCRUNTIME140.dll` file. This file is not included in any newer Windows installation by default. 