### PR TITLE
Remove manual mapping of non-suffixed APIs, which is fixed in MKL 2024.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,25 +19,12 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-13 # intel
-          - macOS-14 # arm
         arch:
           - x64
-          - x86
-          - aarch64
-        exclude:
-          - os: ubuntu-latest
-            arch: aarch64
-          - os: windows-latest
-            arch: aarch64
-          - os: macOS-13
-            arch: x86
-          - os: macOS-13
-            arch: aarch64
+	  - x86
+        include:
           - os: macOS-14
-            arch: x86
-          - os: macOS-14
-            arch: x64
+            arch: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MKL"
 uuid = "33e6dc65-8f57-5167-99aa-e5a354878fb2"
-version = "0.6.4"
+version = "0.7.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -10,7 +10,7 @@ MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [compat]
-julia = "1.8"
+julia = "1.9"
 Artifacts = "1"
 MKL_jll = "2024.1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MKL"
 uuid = "33e6dc65-8f57-5167-99aa-e5a354878fb2"
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -12,7 +12,7 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 [compat]
 julia = "1.8"
 Artifacts = "1"
-MKL_jll = "2022, 2023.2, 2024"
+MKL_jll = "2024.1"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/MKL.jl
+++ b/src/MKL.jl
@@ -40,44 +40,15 @@ function lbt_forward_to_mkl()
         return
     end
 
-    # MKL 2022 and onwards have 64_ for ILP64 suffixes. The LP64 interface
+    # MKL 2024.1 and onwards have 64_ for ILP64 suffixes. The LP64 interface
     # includes LP64 APIs for the non-suffixed symbols and ILP64 API for the
     # 64_ suffixed symbols. LBT4 in Julia is necessary for this to work.
     set_interface_layer(Base.USE_BLAS64 ? INTERFACE_ILP64 : INTERFACE_LP64)
     if Base.USE_BLAS64
         # Load ILP64 forwards
         BLAS.lbt_forward(libmkl_rt; clear=true, suffix_hint="64")
-        # Load LP64 forward
+        # Load LP64 forwards
         BLAS.lbt_forward(libmkl_rt; suffix_hint="")
-
-        # Some BLAS/LAPACK functions that don't have integers in their API aren't exported
-        # from libmkl_rt with the 64 suffix, and instead we must map the ILP64 to the
-        # non-suffixed variants
-        for f in (:dlartgp_,  :slartgp_,
-                  :dlartgs_,  :slartgs_,
-                  :disnan_,   :sisnan_,
-                  :dlabad_,   :slabad_,
-                  :dladiv_,   :sladiv_,
-                  :dlae2_,    :slae2_,
-                  :dlaev2_,   :slaev2_,
-                  :dlaisnan_, :slaisnan_,
-                  :dlamch_,   :slamch_,
-                  :dlamc3_,   :slamc3_,
-                  :dlanv2_,   :slanv2_,
-                  :dlapy2_,   :slapy2_,
-                  :dlapy3_,   :slapy3_,
-                  :dlartg_,   :slartg_,
-                  :dlas2_,    :slas2_,
-                  :dsecnd_,   :second_,
-                  :dlasv2_,   :slasv2_,
-                  :iladiag_,
-                  :ilaprec_,
-                  :ilatrans_,
-                  :ilauplo_,
-                  )
-            fptr = BLAS.lbt_get_forward(f, BLAS.LBT_INTERFACE_LP64)
-            BLAS.lbt_set_forward(f, fptr, BLAS.LBT_INTERFACE_ILP64)
-        end
     else
         BLAS.lbt_forward(libmkl_rt; clear=true, suffix_hint="")
     end


### PR DESCRIPTION
Discussion in https://github.com/JuliaLinearAlgebra/MKL.jl/pull/140#issuecomment-2110250127.

Bumping to 2024.1 will also drop support for MKL on Mac, and threading tests fail on Julia 1.8. As a result Julia 1.9 is the new minimum. As a result, bumping the version to 0.7.

cc @amontoison 