### PR TITLE
Add funcionality to set/get total number of threads (wrapper for `mkl_set_num_threads` and `mkl_get_num_threads`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,16 @@ Libraries:
 
 We use ILP64 by default on 64-bit systems, and LP64 on 32-bit systems.
 
+## Threading control
+
+To set or get the global number of threads used by `MKL`, use `MKL.{set/get}_num_threads`. This does not affect specific domains where the number of threads is set with [`mkl_domain_set_num_threads`](https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-c/2025-0/mkl-domain-set-num-threads.html). Calling `LinearAlgebra.BLAS.{set/get}_num_threads` is domain-specific and only refers to the `BLAS` domain (unlike other backends, where the number of threads used by `LAPACK` is also modified).
+
 ## NOTE: Using MKL with Distributed
 
 If you are using `Distributed` for parallelism on a single node, set MKL to single threaded mode to [avoid over subcribing](https://github.com/JuliaLinearAlgebra/MKL.jl/issues/122) the CPUs. 
 
 ```julia
-BLAS.set_num_threads(1)
+MKL.set_num_threads(1)
 ```
 
 ## NOTE: MKL on Intel Macs

--- a/src/MKL.jl
+++ b/src/MKL.jl
@@ -59,4 +59,11 @@ function mklnorm(x::Vector{Float64})
           (Ref{LinearAlgebra.BlasInt}, Ptr{Float64}, Ref{LinearAlgebra.BlasInt}), length(x), x, 1)
 end
 
+function set_num_threads(n::LinearAlgebra.BlasInt)
+    ccall((:mkl_set_num_threads, libmkl_rt), Cvoid, (Ref{LinearAlgebra.BlasInt},), n)
+end
+
+function get_num_threads()::LinearAlgebra.BlasInt
+    ccall((:mkl_get_max_threads, libmkl_rt), LinearAlgebra.BlasInt, ())
+end
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,13 @@ end
     end
 end
 
+@testset "MKL global threads" begin
+    current_n_threads = MKL.get_num_threads()
+    MKL.set_num_threads(1)
+    @test MKL.get_num_threads() == 1
+    MKL.set_num_threads(current_n_threads)
+end
+
 # Run all the LinearAlgebra stdlib tests, but with MKL.  We still
 # use `Base.runtests()` to get multithreaded, distributed execution
 # to cut down on CI times, and also to restart workers that trip over


### PR DESCRIPTION
This should give to the user the possibility to set the global number of threads, in particular this is the only way to set `LAPACK` threads (see [this](https://community.intel.com/t5/Intel-oneAPI-Math-Kernel-Library/How-to-set-number-of-LAPACK-threads-during-runtime/m-p/1638274#M36554) discussion on MKL forum, and https://github.com/JuliaLinearAlgebra/libblastrampoline/issues/151). Also a section for `Threading control` is added in the Readme.

Solves #174 